### PR TITLE
init: fix starting bmc daemon on shutdown

### DIFF
--- a/tp2bmc/board/tp2bmc/overlay/etc/init.d/S99hello.sh
+++ b/tp2bmc/board/tp2bmc/overlay/etc/init.d/S99hello.sh
@@ -1,24 +1,30 @@
-#! /bin/sh
+#!/bin/sh
 
-mkdir -p /mnt/sdcard
+start() {
+    mkdir -p /mnt/sdcard
 
-if [ -b /dev/mmcblk0p1 ]; then
-    mount /dev/mmcblk0p1 /mnt/sdcard
-elif [ -b /dev/mmcblk0 ]; then
-    mount /dev/mmcblk0 /mnt/sdcard
+    if [ -b /dev/mmcblk0p1 ]; then
+        mount /dev/mmcblk0p1 /mnt/sdcard
+    elif [ -b /dev/mmcblk0 ]; then
+        mount /dev/mmcblk0 /mnt/sdcard
+    fi
+
+    echo " _____ _   _ ____  ___ _   _  ____ "
+    echo "|_   _| | | |  _ \|_ _| \ | |/ ___|"
+    echo "  | | | | | | |_) || ||  \| | |  _ "
+    echo "  | | | |_| |  _ < | || |\  | |_| |"
+    echo "  |_|  \___/|_| \_\___|_| \_|\____|"
+
+    echo 3 4 1 7 > /proc/sys/kernel/printk
+
+    sleep 1
+    /etc/setStaticNet.sh
+
+    bmc &
+
+    /etc/test_ping.sh &
+}
+
+if [ "$1" = "start" ]; then
+    start
 fi
-
-echo " _____ _   _ ____  ___ _   _  ____ "
-echo "|_   _| | | |  _ \|_ _| \ | |/ ___|"
-echo "  | | | | | | |_) || ||  \| | |  _ "
-echo "  | | | |_| |  _ < | || |\  | |_| |"
-echo "  |_|  \___/|_| \_\___|_| \_|\____|"
-
-echo 3 4 1 7 > /proc/sys/kernel/printk
-
-sleep 1
-/etc/setStaticNet.sh
-
-bmc &
-
-/etc/test_ping.sh &


### PR DESCRIPTION
Due to a primitive nature of this init.d script, bmc daemon starts up again on system reboot or shutdown. Normally this isn't a problem and only results in the banner being printed and a second bmc instance started for a brief moment.

However, this causes problems as the new version of bmc gains functionality of an app persistency database, which (for now) stores state of which nodes are powered up, and powers them up or down accordingly, all happening just before the shutdown.

The whitespace-ignored diff:

```diff
diff --git a/tp2bmc/board/tp2bmc/overlay/etc/init.d/S99hello.sh b/tp2bmc/board/tp2bmc/overlay/etc/init.d/S99hello.sh
index 557ac546..caa7b535 100755
--- a/tp2bmc/board/tp2bmc/overlay/etc/init.d/S99hello.sh
+++ b/tp2bmc/board/tp2bmc/overlay/etc/init.d/S99hello.sh
@@ -1,5 +1,6 @@
 #!/bin/sh

+start() {
     mkdir -p /mnt/sdcard

     if [ -b /dev/mmcblk0p1 ]; then
@@ -22,3 +23,8 @@ sleep 1
     bmc &

     /etc/test_ping.sh &
+}
+
+if [ "$1" = "start" ]; then
+    start
+fi
```