### PR TITLE
Updated language from zh-CN to en

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (opencv-testing)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/BMC-Firmware.iml" filepath="$PROJECT_DIR$/.idea/BMC-Firmware.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/tp2bmc/board/tp2bmc/overlay/mnt/var/www/index-normal.asp
+++ b/tp2bmc/board/tp2bmc/overlay/mnt/var/www/index-normal.asp
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN" class="configure">
+<html lang="en" class="configure">
 
 <head>
 

--- a/tp2bmc/board/tp2bmc/overlay/mnt/var/www/index.asp
+++ b/tp2bmc/board/tp2bmc/overlay/mnt/var/www/index.asp
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN" class="configure">
+<html lang="en" class="configure">
 
 <head>
 

--- a/tp2bmc/board/tp2bmc/overlay/mnt/var/www/index.html
+++ b/tp2bmc/board/tp2bmc/overlay/mnt/var/www/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN" class="configure">
+<html lang="en" class="configure">
 
 <head>
 


### PR DESCRIPTION
Fixes the language being set to zh-CN and updates it to en. This is causing browsers to try to translate the page.

Fixes #60 