### PR TITLE
Gh-27 fix versioning tag build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
       
       - name: get version
         run: echo "BUILD_VERSION=`git describe --tags`" >> $GITHUB_ENV


### PR DESCRIPTION
fixes #27 
Make sure to checkout the whole git history, so that git describe can do its work