### PR TITLE
tpi: Add support for specifying which node to perform power action on

### DIFF
--- a/app/tpi/tpi.c
+++ b/app/tpi/tpi.c
@@ -41,15 +41,20 @@ char host[64] = {0};
 
 
 
-bool power(int arg)
+bool power(int arg, int node)
 {
     char cmd[128] = {0};
-    if(arg==1)
-        sprintf(cmd,"curl 'http://%s/api/bmc?opt=set&type=power&node1=1&node2=1&node3=1&node4=1'",host);
-    else if(0==arg)
-        sprintf(cmd,"curl 'http://%s/api/bmc?opt=set&type=power&node1=0&node2=0&node3=0&node4=0'",host);
-    else if(2 == arg)
-    {
+    char nodes[128] = {0};
+
+    if(arg == 0 || arg == 1) {
+      if(node == -1) {
+        sprintf(nodes, "&node1=%1$d&node2=%1$d&node3=%1$d&node4=%1$d", arg);
+      } else {
+        sprintf(nodes,"&node%d=%d", node+1, arg);
+      }
+
+      sprintf(cmd,"curl 'http://%s/api/bmc?opt=set&type=power%s'",host, nodes);
+    } else {
         sprintf(cmd,"curl 'http://%s/api/bmc?opt=get&type=power'",host);
     }
     system(cmd);
@@ -560,7 +565,7 @@ int main(int argc, char *argv[])
     {
         case 0:
         {
-            power(power_cmd);
+            power(power_cmd, node);
             break;
         }
         case 1:


### PR DESCRIPTION
Quick and dirty patch to add support for specifying which node to turn on or off via `-n <n>`. Not sure if this is wanted/needed since tpi_rs seems to be the future, but thought I'd put it out there anyway. Feel free to close.

tpi still works as usual:
```
# ./tpi -p status
{
	"response":	[{
			"node1":	0,
			"node2":	0,
			"node3":	0,
			"node4":	0
		}]
}
# ./tpi -p on
{"response":[{"result":"ok"}]}
# ./tpi -p status
{
	"response":	[{
			"node1":	1,
			"node2":	1,
			"node3":	1,
			"node4":	1
		}]
}
# ./tpi -p off
{"response":[{"result":"ok"}]}
# ./tpi -p status
{
	"response":	[{
			"node1":	0,
			"node2":	0,
			"node3":	0,
			"node4":	0
		}]
}
```
But now, we can specify individual nodes with `-n`
```
# ./tpi -p on -n 1
{"response":[{"result":"ok"}]}
# ./tpi -p on -n 3
{"response":[{"result":"ok"}]}
# ./tpi -p status
{
	"response":	[{
			"node1":	1,
			"node2":	0,
			"node3":	1,
			"node4":	0
		}]
}
# ./tpi -p off -n 3
{"response":[{"result":"ok"}]}
# ./tpi -p status
{
	"response":	[{
			"node1":	1,
			"node2":	0,
			"node3":	0,
			"node4":	0
		}]
}
```

