### PR TITLE
Correct the USB-OTG line polarity in the new GPIO aggregator node

### DIFF
--- a/tp2bmc/board/tp2bmc/sun8iw20p1-t113-turingmachines-tp2bmc.dts
+++ b/tp2bmc/board/tp2bmc/sun8iw20p1-t113-turingmachines-tp2bmc.dts
@@ -81,29 +81,29 @@
 
 		gpios = <&pio PD 11 GPIO_ACTIVE_LOW>, /* node 1 */
 			<&pio PD  0 GPIO_ACTIVE_LOW>,
-			<&pio PD 19 GPIO_ACTIVE_LOW>,
+			<&pio PD 19 GPIO_ACTIVE_HIGH>,
 			<&pio PD 15 GPIO_ACTIVE_LOW>,
 			<&pio PD 10 GPIO_ACTIVE_LOW>, /* node 2 */
 			<&pio PD 20 GPIO_ACTIVE_LOW>,
-			<&pio PD 18 GPIO_ACTIVE_LOW>,
+			<&pio PD 18 GPIO_ACTIVE_HIGH>,
 			<&pio PD 14 GPIO_ACTIVE_LOW>,
 			<&pio PD  9 GPIO_ACTIVE_LOW>, /* node 3 */
 			<&pio PD 21 GPIO_ACTIVE_LOW>,
-			<&pio PD 17 GPIO_ACTIVE_LOW>,
+			<&pio PD 17 GPIO_ACTIVE_HIGH>,
 			<&pio PD 12 GPIO_ACTIVE_LOW>,
 			<&pio PD  8 GPIO_ACTIVE_LOW>, /* node 4 */
 			<&pio PD 22 GPIO_ACTIVE_LOW>,
-			<&pio PD 16 GPIO_ACTIVE_LOW>,
+			<&pio PD 16 GPIO_ACTIVE_HIGH>,
 			<&pio PD 13 GPIO_ACTIVE_LOW>;
 
 		gpio-line-names = "node1-en", "node1-rst",
-				  "node1-usb-vbus", "node1-rpiboot",
+				  "node1-usbotg-dev", "node1-rpiboot",
 				  "node2-en", "node2-rst",
-				  "node2-usb-vbus", "node2-rpiboot",
+				  "node2-usbotg-dev", "node2-rpiboot",
 				  "node3-en", "node3-rst",
-				  "node3-usb-vbus", "node3-rpiboot",
+				  "node3-usbotg-dev", "node3-rpiboot",
 				  "node4-en", "node4-rst",
-				  "node4-usb-vbus", "node4-rpiboot";
+				  "node4-usbotg-dev", "node4-rpiboot";
 	};
 
 	// Voltage regulators (there are 7 main ones):


### PR DESCRIPTION
The lines are also renamed from usb-vbus to make it clear that this is NOT controlling a regulator; it's a sense signal for whether the USBOTG controller should run in device mode.

I hope that this will fix that mystery regression @svenrademakers was experiencing which caused this branch to be reverted the first time around.

(**N.B.** this PR goes into `feature/dts_updates`, not `master`, so it shouldn't require as much scrutiny. I would recommend a cherry-pick/rebase over a full merge commit, as well.)