### PR TITLE
package/bmcd: bump to latest & enable rockusb driver

### DIFF
--- a/tp2bmc/board/tp2bmc/overlay/etc/init.d/S92modules
+++ b/tp2bmc/board/tp2bmc/overlay/etc/init.d/S92modules
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+MODULES="modules"
+
+load_unload() {
+	[ ! -f /etc/${MODULES} ] && echo ' OK' && exit 0
+
+	while read module args; do
+
+		case "$module" in
+			""|"#"*) continue ;;
+		esac
+
+		if [ "$1" = "load" ]; then
+			modprobe -q ${module} ${args} >/dev/null && \
+				printf ' %s success,' "$module" ||
+				printf ' %s failed,' "$module"
+		else
+			rmmod ${module} >/dev/null
+		fi
+
+	done < /etc/${MODULES}
+}
+
+start() {
+	printf 'Starting %s:' "$MODULES"
+
+	load_unload load
+
+	echo ' OK'
+}
+
+stop() {
+	printf 'Stopping %s: ' "$MODULES"
+
+	load_unload unload
+
+	echo 'OK'
+}
+
+restart() {
+	stop
+	sleep 1
+	start
+}
+
+case "$1" in
+	start|stop|restart)
+		"$1";;
+	reload)
+		# Restart, since there is no true "reload" feature.
+		restart;;
+	*)
+		echo "Usage: $0 {start|stop|restart|reload}"
+		exit 1
+esac

--- a/tp2bmc/board/tp2bmc/overlay/etc/modules
+++ b/tp2bmc/board/tp2bmc/overlay/etc/modules
@@ -1,0 +1,1 @@
+rockusb

--- a/tp2bmc/package/bmcd/S94bmcd
+++ b/tp2bmc/package/bmcd/S94bmcd
@@ -9,8 +9,6 @@ KEYFILE="/etc/ssl/certs/bmcd_key.pem"
 start() {
     printf 'Starting %s...\n' "$DAEMON"
 
-    modprobe rockusb
-
     [ ! -f "$CERTFILE" ] || [ ! -f "$KEYFILE" ] && /etc/bmcd/generate_self_signedx509.sh 
 
     start-stop-daemon --start --quiet --background --make-pidfile --pidfile "$PIDFILE" --no-close \

--- a/tp2bmc/package/bmcd/S94bmcd
+++ b/tp2bmc/package/bmcd/S94bmcd
@@ -9,6 +9,8 @@ KEYFILE="/etc/ssl/certs/bmcd_key.pem"
 start() {
     printf 'Starting %s...\n' "$DAEMON"
 
+    modprobe rockusb
+
     [ ! -f "$CERTFILE" ] || [ ! -f "$KEYFILE" ] && /etc/bmcd/generate_self_signedx509.sh 
 
     start-stop-daemon --start --quiet --background --make-pidfile --pidfile "$PIDFILE" --no-close \

--- a/tp2bmc/package/bmcd/bmcd.mk
+++ b/tp2bmc/package/bmcd/bmcd.mk
@@ -3,7 +3,7 @@
 # bmcd
 ###########################################################
 
-BMCD_VERSION = e1d147329355e8618ffcb41a0edd538950e367a9
+BMCD_VERSION = 0bf5591719ed5cd64e636221f05264adbfb5beab
 BMCD_SITE = $(call github,turing-machines,bmcd,$(BMCD_VERSION))
 BMCD_LICENSE = Apache-2.0
 BMCD_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This sets version of bmcd to latest, and also enables the driver that it relies on.

Related to #137