### PR TITLE
Update sshd_config

### DIFF
--- a/tp2bmc/board/tp2bmc/overlay/etc/ssh/sshd_config
+++ b/tp2bmc/board/tp2bmc/overlay/etc/ssh/sshd_config
@@ -35,6 +35,7 @@
 #MaxSessions 10
 
 #PubkeyAuthentication yes
+PermitRootLogin yes
 
 # The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
 # but this is overridden so installations will only check .ssh/authorized_keys
@@ -54,8 +55,8 @@ AuthorizedKeysFile	.ssh/authorized_keys
 #IgnoreRhosts yes
 
 # To disable tunneled clear text passwords, change to no here!
-#PasswordAuthentication yes
-#PermitEmptyPasswords no
+PasswordAuthentication yes
+PermitEmptyPasswords no
 
 # Change to no to disable s/key passwords
 #KbdInteractiveAuthentication yes
@@ -114,6 +115,3 @@ Subsystem	sftp	/usr/libexec/sftp-server
 #	AllowTcpForwarding no
 #	PermitTTY no
 #	ForceCommand cvs server
-PasswordAuthentication yes # add by wenyi
-PermitEmptyPasswords yes   # add by wenyi
-PermitRootLogin yes 


### PR DESCRIPTION
- Removed duplicate lines with potentially insecure settings from bottom of file
- Removed refrences to Wenyi from comments - users unfamilliar with the projects history may (rightly IMO) be concerened by these otherwise)
- Explititly set `PermitRootLogin` to yes and move to under `PubkeyAuthentication` as a hint to users to change this setting and setup key based auth - as per the docs
- Change `PermitEmptyPasswords` to `no` - root user has default password of `turing` set so there doesn't seem to be a good reason to have this set to yes. "No" is the sshd_config defalt but the line is usually commented, I have no commented it as this would be a change from previous firmware versions so wanted ot be explicit about it.