### PR TITLE
QoL: include hostname & pwd in prompt, uart helpers

### DIFF
--- a/tp2bmc/board/tp2bmc/overlay/etc/profile.d/prompt.sh
+++ b/tp2bmc/board/tp2bmc/overlay/etc/profile.d/prompt.sh
@@ -1,0 +1,3 @@
+if tty | grep -q '^/dev/pts'; then
+	export PS1='\h \w \$ '
+fi

--- a/tp2bmc/board/tp2bmc/overlay/usr/bin/uart1
+++ b/tp2bmc/board/tp2bmc/overlay/usr/bin/uart1
@@ -1,0 +1,1 @@
+exec picocom /dev/ttyS1 -b 115200

--- a/tp2bmc/board/tp2bmc/overlay/usr/bin/uart2
+++ b/tp2bmc/board/tp2bmc/overlay/usr/bin/uart2
@@ -1,0 +1,1 @@
+exec picocom /dev/ttyS2 -b 115200

--- a/tp2bmc/board/tp2bmc/overlay/usr/bin/uart3
+++ b/tp2bmc/board/tp2bmc/overlay/usr/bin/uart3
@@ -1,0 +1,1 @@
+exec picocom /dev/ttyS3 -b 115200

--- a/tp2bmc/board/tp2bmc/overlay/usr/bin/uart4
+++ b/tp2bmc/board/tp2bmc/overlay/usr/bin/uart4
@@ -1,0 +1,1 @@
+exec picocom /dev/ttyS4 -b 115200


### PR DESCRIPTION
Throwing these out here, but its up to y'all if you want either:

## `/usr/bin/uart{1,2,3,4}`

These uart helpers were a more important sanity check for me before #181 got finished

but for those of us less accustomed to working with serial consoles, the buad rate number is also hard to remember confidently

[Also is there any chance any parity checking or similar QoS improvement is/can be made available here? (and the appropriate flags to picocom wrapped into these invocations), cause

I was trying to deal with a thing in u-boot earlier and the amount of lines and characters going missing was … frustrating]

## `/etc/profile.d/prompt.sh`

these prompt vars work fine in busybox's sh 
(as well as bash - which … given that its getting included in the build already, is there a reason not to make it root's login shell?)

I put the pts guard around it under the premise that over serial, the simpler prompt might still be preferred, but idk if that's true or not in practice