### PR TITLE
Download bmc-ui from GitHub releases

### DIFF
--- a/tp2bmc/package/bmc-ui/bmc-ui.mk
+++ b/tp2bmc/package/bmc-ui/bmc-ui.mk
@@ -3,7 +3,7 @@
 # bmc-ui
 ###########################################################
 
-BMC_UI_VERSION = v2.1.0
+BMC_UI_VERSION = v3.0.0
 BMC_UI_SITE = https://github.com/turing-machines/BMC-UI/releases/download/$(BMC_UI_VERSION)
 BMC_UI_LICENSE = GPL-2.0
 BMC_UI_LICENSE_FILES = LICENSE

--- a/tp2bmc/package/bmc-ui/bmc-ui.mk
+++ b/tp2bmc/package/bmc-ui/bmc-ui.mk
@@ -3,15 +3,14 @@
 # bmc-ui
 ###########################################################
 
-BMC_UI_VERSION = 18c45c3a62d2cf2d682e864be303adf13568fc7a
-BMC_UI_SITE = $(call github,turing-machines,BMC-UI,$(BMC_UI_VERSION))
+BMC_UI_VERSION = v2.1.0
+BMC_UI_SITE = https://github.com/turing-machines/BMC-UI/releases/download/$(BMC_UI_VERSION)
 BMC_UI_LICENSE = GPL-2.0
 BMC_UI_LICENSE_FILES = LICENSE
 define BMC_UI_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/srv/bmcd/www/
-	cp -r $(BMC_UI_SRCDIR)/dist/* $(TARGET_DIR)/srv/bmcd/www/
+	cp -r $(BMC_UI_SRCDIR)* $(TARGET_DIR)/srv/bmcd/www/
 	chmod 755 $(TARGET_DIR)/srv/bmcd/www/
-	sed -i 's/%BMC_UI%/$(BMC_UI_VERSION)/g' $(TARGET_DIR)/srv/bmcd/www/index.html
 endef
 
 $(eval $(generic-package))

--- a/tp2bmc/package/bmcd/bmcd.mk
+++ b/tp2bmc/package/bmcd/bmcd.mk
@@ -3,7 +3,7 @@
 # bmcd
 ###########################################################
 
-BMCD_VERSION = 4e6dffa928629c1066f6c0cf4414d6c399b725b3
+BMCD_VERSION = a525f331627535fd7173f93554dba85fe641c42b
 BMCD_SITE = $(call github,turing-machines,bmcd,$(BMCD_VERSION))
 BMCD_LICENSE = Apache-2.0
 BMCD_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This aims to support the new build procedure for production releases proposed in https://github.com/turing-machines/BMC-UI/pull/5, to not commit the whole `/dist` folder into the repository.

The following workflow has been tested E2E via https://github.com/barrenechea/BMC-Firmware/actions/runs/8868645485

This should be modified and merged at the end, following:
- ~~Approval & merge of https://github.com/turing-machines/BMC-UI/pull/5 & the pipeline successfully running the new release workflow.~~ Done 🎉  v3.0.0 was released.
- ~~Approval & merge of https://github.com/turing-machines/bmcd/pull/86~~ Done 🎉 

~~After those events, this PR should target the released BMC-UI version and the latest `bmcd` commit so we can run the new SpA without Basic Auth.~~ Done! 🎉 