### PR TITLE
tune vm

### DIFF
--- a/tp2bmc/board/tp2bmc/overlay/etc/sysctl.conf
+++ b/tp2bmc/board/tp2bmc/overlay/etc/sysctl.conf
@@ -1,0 +1,3 @@
+vm.vfs_cache_pressure=130
+vm.dirty_ratio=10
+vm.overcommit_ratio=20


### PR DESCRIPTION
This commits aims to reduce the amount of dirty pages in the cache by lowing the ratio of bytes allowed for page-caching Secondly, the vfs_cache_pressure is increased to put more emphasis on reclaiming inodes and dentries.