### PR TITLE
bumps: buildroot to 2024.05.1, build base image to Ubuntu 24.04, gh actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
             /work/setup_build.sh
             cd /work/buildroot
             make BR2_EXTERNAL=../tp2bmc tp2bmc_defconfig
-            FORCE_UNSAFE_CONFIGURE=1 make
+            make
 
       - name: stamp images
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
       - name: Maximize build space
-        uses: AdityaGarg8/remove-unwanted-software@v1
+        uses: AdityaGarg8/remove-unwanted-software@v4.1
         with:
           remove-android: 'true'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
       
@@ -52,7 +52,7 @@ jobs:
          sed -ir 's#^BMCD_VERSION.*#BMCD_VERSION=${{ inputs.bmcd_version }}#g' ${{ github.workspace }}/tp2bmc/package/bmcd/bmcd.mk
 
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v4
+      - uses: docker/build-push-action@v6
         with:
           context: .
           tags: buildroot_local:latest
@@ -60,6 +60,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: false
+        env:
+          DOCKER_BUILD_SUMMARY: false
 
       - name: build firmware
         uses: addnab/docker-run-action@v3
@@ -79,9 +81,8 @@ jobs:
           sudo mv buildroot/output/images/rootfs.erofs artifacts/tp2-ota-${{ env.BUILD_VERSION }}.tpu
 
       - name: archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error 
           name: tp2-${{ env.BUILD_VERSION }}
           path: artifacts/*
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu22.04
+FROM mcr.microsoft.com/devcontainers/base:ubuntu24.04
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -24,4 +24,6 @@ RUN apt-get update && apt-get install -y \
     libncurses-dev \
     u-boot-tools \
     mkbootimg \
-    && rm -rf /var/lib/apt/lists/*
+    xxd \
+    && rm -rf /var/lib/apt/ \
+    && rm -rf /var/cache/apt/

--- a/setup_build.sh
+++ b/setup_build.sh
@@ -9,7 +9,7 @@
 #
 
 set -x
-BUILDROOT_VER="2024.05"
+BUILDROOT_VER="2024.05.1"
 
 download_dir=$(mktemp -d)
 install_dir="$1"


### PR DESCRIPTION
A few updates! 😄 it was initially just Buildroot, but I pushed it a bit more

- Bumped Buildroot to 2024.05.1 ([changelog here](https://gitlab.com/buildroot.org/buildroot/-/blob/2024.05.1/CHANGES)). It is mostly security-related fixes. The kernel remains at v6.8.12.

- Bumped all GitHub Actions, addresses the currently existing warnings after each run:
  <img width="1352" alt="Screenshot 2024-07-29 at 3 45 40 PM" src="https://github.com/user-attachments/assets/d98e4601-3488-40f6-a625-90c3319447a8">
  - For `build-push-action`, since v6, they added "[Summaries](https://github.com/docker/build-push-action/tree/v6/?tab=readme-ov-file#summaries)". This is not useful for this case where the built image is just used for the build procedure, so I disabled it with the `DOCKER_BUILD_SUMMARY` environment variable.

- Bumped base image to Ubuntu 24.04, fixing the issue of trying to build `host-tar-1.35`, making the `FORCE_UNSAFE_CONFIGURE` flag no longer needed.
