### PR TITLE
build: bump rust to 1.80.0

### DIFF
--- a/buildroot_patches/0002-bump-rust-to-1.80.patch
+++ b/buildroot_patches/0002-bump-rust-to-1.80.patch
@@ -1,7 +1,7 @@
 From f2cd287bc49fee60b1c8f2c537b2e5c71ca7c348 Mon Sep 17 00:00:00 2001
 From: Sven Rademakers <sven.rademakers@gmail.com>
 Date: Wed, 13 Mar 2024 15:55:30 +0000
-Subject: [PATCH] bump rust to 1.79
+Subject: [PATCH] bump rust to 1.80
 
 ---
  buildroot/package/rust-bin/rust-bin.hash | 111 ---------------------------------
@@ -138,7 +138,7 @@ index ca35d27d1c..6cee57ece9 100644
  # When updating this version, check whether support/download/cargo-post-process
  # still generates the same archives.
 -RUST_BIN_VERSION = 1.74.1
-+RUST_BIN_VERSION = 1.79.0
++RUST_BIN_VERSION = 1.80.0
  RUST_BIN_SITE = https://static.rust-lang.org/dist
  RUST_BIN_LICENSE = Apache-2.0 or MIT
  RUST_BIN_LICENSE_FILES = LICENSE-APACHE LICENSE-MIT
@@ -163,7 +163,7 @@ index c544582c99..23e46fca2c 100644
  # When updating this version, check whether support/download/cargo-post-process
  # still generates the same archives.
 -RUST_VERSION = 1.74.1
-+RUST_VERSION = 1.79.0
++RUST_VERSION = 1.80.0
  RUST_SOURCE = rustc-$(RUST_VERSION)-src.tar.xz
  RUST_SITE = https://static.rust-lang.org/dist
  RUST_LICENSE = Apache-2.0 or MIT


### PR DESCRIPTION
I just noticed the new Rust release `1.80.0` after my local version was updated by `brew`, so I figured that bumping it over this repo would be nice 😄

Opening this PR after checking that the firmware correctly builds and runs on my cluster