### PR TITLE
Increase drive strength on i2c2 to fix communication issues

### DIFF
--- a/tp2bmc/board/tp2bmc/sun8i-t113s-turing-pi2.dtsi
+++ b/tp2bmc/board/tp2bmc/sun8i-t113s-turing-pi2.dtsi
@@ -125,7 +125,7 @@
 	i2c2_pe12_pins: i2c2-pe12-pins {
 		pins = "PE12", "PE13";
 		function = "i2c2";
-		drive-strength = <10>;
+		drive-strength = <20>;
 	};
 
 	uart2_pd_pins: uart2-pd-pins {


### PR DESCRIPTION
This fixes the I2C communication errors on i2c2 resulting in the BMC losing network connectivity