### PR TITLE
bmcd: added feature that disables writing the state to filesystem.

### DIFF
--- a/tp2bmc/package/bmcd/bmcd.mk
+++ b/tp2bmc/package/bmcd/bmcd.mk
@@ -3,7 +3,7 @@
 # bmcd
 ###########################################################
 
-BMCD_VERSION = v2.3.2
+BMCD_VERSION = v2.3.3
 BMCD_SITE = $(call github,turing-machines,bmcd,$(BMCD_VERSION))
 BMCD_LICENSE = Apache-2.0
 BMCD_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This is as of now a relatively undocumented feature, which aims to make to the factory procedure more smooth.