### PR TITLE
feat: update bmc-ui to v3.3.6

### DIFF
--- a/tp2bmc/package/bmc-ui/bmc-ui.mk
+++ b/tp2bmc/package/bmc-ui/bmc-ui.mk
@@ -3,7 +3,7 @@
 # bmc-ui
 ###########################################################
 
-BMC_UI_VERSION = v3.3.3
+BMC_UI_VERSION = v3.3.6
 BMC_UI_SITE = https://github.com/turing-machines/BMC-UI/releases/download/$(BMC_UI_VERSION)
 BMC_UI_LICENSE = GPL-2.0
 BMC_UI_LICENSE_FILES = LICENSE


### PR DESCRIPTION
## Update bmc-ui

This PR is to update the bmc-ui in the firmware to v3.3.6 to ensure PR [#22](https://github.com/turing-machines/BMC-UI/issues/22) makes it into the upcoming release v2.1.
