### PR TITLE
fix: align versioning and write official firmware version

### DIFF
--- a/buildroot_patches/0002-bump-rust-to-1.85.patch
+++ b/buildroot_patches/0002-bump-rust-to-1.85.patch
@@ -1,7 +1,7 @@
 From f2cd287bc49fee60b1c8f2c537b2e5c71ca7c348 Mon Sep 17 00:00:00 2001
 From: Sven Rademakers <sven.rademakers@gmail.com>
 Date: Wed, 13 Mar 2024 15:55:30 +0000
-Subject: [PATCH] bump rust to 1.79
+Subject: [PATCH] bump rust to 1.85
 
 ---
  buildroot/package/rust-bin/rust-bin.hash | 111 ---------------------------------
@@ -134,11 +134,11 @@ index ca35d27d1c..6cee57ece9 100644
 --- a/package/rust-bin/rust-bin.mk
 +++ b/package/rust-bin/rust-bin.mk
 @@ -6,7 +6,7 @@
- 
+
  # When updating this version, check whether support/download/cargo-post-process
  # still generates the same archives.
 -RUST_BIN_VERSION = 1.74.1
-+RUST_BIN_VERSION = 1.79.0
++RUST_BIN_VERSION = 1.85.0
  RUST_BIN_SITE = https://static.rust-lang.org/dist
  RUST_BIN_LICENSE = Apache-2.0 or MIT
  RUST_BIN_LICENSE_FILES = LICENSE-APACHE LICENSE-MIT
@@ -159,14 +159,14 @@ index c544582c99..23e46fca2c 100644
 --- a/package/rust/rust.mk
 +++ b/package/rust/rust.mk
 @@ -6,7 +6,7 @@
- 
+
  # When updating this version, check whether support/download/cargo-post-process
  # still generates the same archives.
 -RUST_VERSION = 1.74.1
-+RUST_VERSION = 1.79.0
++RUST_VERSION = 1.85.0
  RUST_SOURCE = rustc-$(RUST_VERSION)-src.tar.xz
  RUST_SITE = https://static.rust-lang.org/dist
  RUST_LICENSE = Apache-2.0 or MIT
--- 
+--
 2.44.0
 

--- a/tp2bmc/board/tp2bmc/post_build.sh
+++ b/tp2bmc/board/tp2bmc/post_build.sh
@@ -28,7 +28,7 @@ overwrite_os_release() {
         build_version=$(git describe --tags)
         if [[ $? -ne 0 ]]; then
             echo "Error: Failed to get version from git describe"
-            build_vrsion="v2-unknown"
+            build_version="v2-unknown"
         fi
     fi
 

--- a/tp2bmc/board/tp2bmc/post_build.sh
+++ b/tp2bmc/board/tp2bmc/post_build.sh
@@ -17,3 +17,27 @@ if [ -e ${TARGET_DIR}/etc/inittab ]; then
     sed -i '/GENERIC_SERIAL/a\
 GS0::respawn:/sbin/getty -L ttyGS0 115200 vt100 # BMC-USB-OTG' ${TARGET_DIR}/etc/inittab
 fi
+
+
+# tries to retrieve the official firmware version and print it into
+# /etc/os-release
+overwrite_os_release() {
+    if [[ -n "$BUILD_VERSION" ]]; then
+        build_version="$BUILD_VERSION"
+    else
+        build_version=$(git describe --tags)
+        if [[ $? -ne 0 ]]; then
+            echo "Error: Failed to get version from git describe"
+            build_vrsion="v2-unknown"
+        fi
+    fi
+
+    os_release_file="/etc/os-release"
+
+    echo "NAME=turingpi" > "$os_release_file"
+    echo "PRETTY_NAME=Turing Pi ${build_version%%-*}" >> "$os_release_file"
+    echo "VERSION=${build_version}" >> "$os_release_file"
+    echo "Firmware version set to ${build_version}"
+}
+
+overwrite_os_release

--- a/tp2bmc/package/bmcd/bmcd.mk
+++ b/tp2bmc/package/bmcd/bmcd.mk
@@ -3,7 +3,7 @@
 # bmcd
 ###########################################################
 
-BMCD_VERSION = v2.3.4
+BMCD_VERSION = v2.3.7
 BMCD_SITE = $(call github,turing-machines,bmcd,$(BMCD_VERSION))
 BMCD_LICENSE = Apache-2.0
 BMCD_LICENSE_FILES = LICENSE


### PR DESCRIPTION
/etc/os-release will now contain the official version of the turing-pi firmware under the key `VERSION`.

The version will be determined by `git describe --tags` and can be overwritten during the build by setting the env var `BUILD_VERSION`

part of #240