### PR TITLE
Fix devcontainer and configure scripts

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -78,7 +78,7 @@ else
 fi
 
 if [ -e "$install_dir/$buildroot_target" ]; then
-    rm -rf "$install_dir/${buildroot_target:?}/"*
+    rm -rf "$install_dir/${buildroot_target:?}/"
 fi
 
 mv "$download_dir/$buildroot_folder" "$install_dir/$buildroot_target"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -11,7 +11,7 @@ sudo chown vscode:vscode /work
 
 # Configure git config
 # initialize git config before initial sync of .git directory
-git config --local include.path ../.gitconfig
+git config --global include.path "${PWD}/.gitconfig"
 
 if [[ "${HOST_OS^^}" == "DARWIN" ]]; then
     # Sync Git only for initial sync

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -6,10 +6,10 @@ set -eo pipefail
 if [[ "${HOST_OS^^}" == "DARWIN" ]]; then
     # Sync container back to repository
     echo "Syncing container back to repository"
-    rsync -hrPti --delete --update --fsync --exclude buildroot --exclude .git /work/ /mnt > /tmp/sync.log
+    rsync -hrPti --update --fsync --exclude buildroot --exclude .git --exclude dist /work/ /mnt | tee -a /tmp/sync.log
     
     echo "Syncing repository to container"
-    rsync -hrPti --delete --update --fsync --exclude buildroot --exclude .git /mnt/ /work > /tmp/sync.log
+    rsync -hrPti --delete --update --fsync --exclude buildroot --exclude .git /mnt/ /work | tee -a /tmp/sync.log
 else
     echo "sync.sh is only used on macOS"
     exit 1


### PR DESCRIPTION
The current devcontainer setup is seemingly broken.

Some of these issues seem to be MacOS specific, others are generic.

- If running the `scripts/configure.sh` script multiple times, only the first run will succeed with patching files.
The first time, the buildroot directory is created and populated with the content of the downloaded buildroot tar.gz
file.
On subsequent runs, this directory should be cleaned up and then re-populated.
Instead, only the directory contents are cleaned up, never the directory itself leading to the buildroot data ending up
in a versioned subdirectory.
The versioned subdirectory also means, the `scripts/build.sh` script will never run correctly on subsequent runs.

- The scripts/init.sh part is throwing a git error about `fatal: --local can only be used inside a git repository`
which is due to at least current git releases refusing to do a local configuration change outside a git repository.
This seems to have affected other people as well (https://github.com/peter-evans/create-pull-request/issues/1170)
and the only way to fix this is to configure the git include using the `--global` flag.
As we're in a container, we do not even need to clean up behind us as we're only ever changing the git config inside
the container. 🎉

- The `scripts/sync.sh` - which is used exclusively on MacOS machines - will happily remove the `dist` folder used to hold finished firmware images just after they got built.
Exclude that when `rsync` is called and enable rsync output to the terminal so that one can understand what is going on.